### PR TITLE
fixed parse_cli

### DIFF
--- a/lib/ansible/plugins/filter/network.py
+++ b/lib/ansible/plugins/filter/network.py
@@ -120,7 +120,7 @@ def parse_cli(output, tmpl):
                     block_started = True
 
                 elif match_end:
-                    if lines:
+                    if block_started:
                         lines.append(line)
                         blocks.append('\n'.join(lines))
                     block_started = False


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
It will end a block only if it has been started, avoiding multiple blocks creation.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
For example if we have:
```
  start
    value
  end
  end
```
the filter will report 2 blocks instead of only 1. With this fix it will report only the first one 
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
